### PR TITLE
Docker compose'ifying eyes-in-the-sky

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,20 +12,28 @@ This repo contains the following:
 
 1. Make sure Docker is installed on your raspberry pi:
 
+    ```
     $ curl -sSL https://get.docker.com | sh
+    ```
 
 2. Clone the repo on your raspberry pi:
 
+    ```
     $ git clone https://github.com/LoungeFlyZ/eyes-in-the-sky
+    ```
 
 3. Download a copy of docker-compose for raspberry pi:
 
+    ```
     $ wget -O docker-compose https://github.com/javabean/arm-compose/releases/download/1.16.1/docker-compose-Linux-armv7l
     $ chmod +x docker-compose
+    ```
 
 4. Edit docker-compose.yml 
 
+    ```
     $ nano docker-compose.yml
+    ```
     
 5. Replace the following environment configuration with your own settings:
 
@@ -37,7 +45,9 @@ This repo contains the following:
 
 6. docker-compose up
 
+    ```
     $ docker-compose -f docker-compose.yml up -d
+    ```
     
 7. browse to your raspberry pi's ip address on port 8080
  
@@ -49,8 +59,12 @@ You should now see dump1090's web interface.
 
 - Check the logs for the piaware container
 
+    ```
     $ docker logs piaware
+    ```
     
 - Check the logs for the dump1090 container
 
+    ```
     $ docker logs dump1090
+    ```

--- a/README.md
+++ b/README.md
@@ -56,6 +56,16 @@ This repo contains the following:
     
 You should now see dump1090's web interface.
 
+## Setting your feeder id
+
+Log into your FlightAware account and find your new feeder on the "My ADS-B" page. Every time a new feeder is detected FlightAware assigns a unique identifier (guid) to it. To ensure your piaware container is not seen as a new feeder each time it is restarted you need to get the "unique identifier" from your My ADS-B stats page and set it in the docker-compose.yml file.
+
+    ```
+    - PIAWARE_FEEDER_ID=532e29ff-ed56-4b7b-72b6-12b56313b49a
+    ```
+
+This will ensure that when your piaware container is restarted that it is seen as the same feeder in flightaware. 
+
 ## Troubleshooting
 
 - Check the logs for the piaware container

--- a/README.md
+++ b/README.md
@@ -2,11 +2,13 @@
 
 Instructions and Dockerfiles for tracking flights with your Raspberry Pi and a USB TV stick.
 
+Inspired by Alex Ellis' blog post: [Get eyes in the sky with your Raspberry Pi](https://blog.alexellis.io/track-flights-with-rpi/)
+
 This repo contains the following:
 
-* dump1090 - A docker container for [MalcolmRobb/dump1090](https://github.com/malcolmrobb/dump1090) that is a simple Mode S decoder for RTLSDR devices
-* flightaware - A docker container for [PiAware](http://flightaware.com/adsb/piaware/)
-* docker-compose.yml - A docker compose file where all configuration is made. 
+* dump1090 - A docker container for [MalcolmRobb/dump1090](https://github.com/malcolmrobb/dump1090) that is a simple Mode S decoder for [RTLSDR devices](http://flightaware.com/adsb/prostick/).
+* flightaware - A docker container for FlightAware.com's [PiAware](http://flightaware.com/adsb/piaware/) feeder app.
+* docker-compose.yml - A docker compose file where all configuration is made.
 
 ## Simple setup
 

--- a/README.md
+++ b/README.md
@@ -2,3 +2,55 @@
 
 Instructions and Dockerfiles for tracking flights with your Raspberry Pi and a USB TV stick.
 
+This repo contains the following:
+
+* dump1090 - A docker container for [MalcolmRobb/dump1090](https://github.com/malcolmrobb/dump1090) that is a simple Mode S decoder for RTLSDR devices
+* flightaware - A docker container for [PiAware](http://flightaware.com/adsb/piaware/)
+* docker-compose.yml - A docker compose file where all configuration is made. 
+
+## Simple setup
+
+1. Make sure Docker is installed on your raspberry pi:
+
+    $ curl -sSL https://get.docker.com | sh
+
+2. Clone the repo on your raspberry pi:
+
+    $ git clone https://github.com/LoungeFlyZ/eyes-in-the-sky
+
+3. Download a copy of docker-compose for raspberry pi:
+
+    $ wget -O docker-compose https://github.com/javabean/arm-compose/releases/download/1.16.1/docker-compose-Linux-armv7l
+    $ chmod +x docker-compose
+
+4. Edit docker-compose.yml 
+
+    $ nano docker-compose.yml
+    
+5. Replace the following environment configuration with your own settings:
+
+    - `DUMP_LAT` - Your latitude
+    - `DUMP_LON` - Your longitude
+    - `PIAWARE_USER` - Your FlightAware.com username
+    - `PIAWARE_PASSWORD` - Your FlightAware.com password
+    - `PIAWARE_FEEDER_ID` (Optional) - Your feeder id from FlightAware if you already have one
+
+6. docker-compose up
+
+    $ docker-compose -f docker-compose.yml up -d
+    
+7. browse to your raspberry pi's ip address on port 8080
+ 
+    [http://192.168.1.200:8080](http://192.168.1.200:8080) _(replace with your ip)_
+    
+You should now see dump1090's web interface.
+
+## Troubleshooting
+
+- Check the logs for the piaware container
+
+    $ docker logs piaware
+    
+- Check the logs for the dump1090 container
+
+    $ docker logs dump1090

--- a/README.md
+++ b/README.md
@@ -24,11 +24,10 @@ This repo contains the following:
     $ git clone https://github.com/LoungeFlyZ/eyes-in-the-sky
     ```
 
-3. Download a copy of docker-compose for raspberry pi:
+3. Install docker-compose:
 
     ```
-    $ wget -O docker-compose https://github.com/javabean/arm-compose/releases/download/1.16.1/docker-compose-Linux-armv7l
-    $ chmod +x docker-compose
+    $ sudo apt-get -y install python-setuptools && sudo easy_install pip  && sudo pip install docker-compose
     ```
 
 4. Edit docker-compose.yml 

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ This repo contains the following:
     
 You should now see dump1090's web interface.
 
-## Setting your feeder id
+## Setting your feeder id -- FlightAware.com
 
 Log into your FlightAware account and find your new feeder on the "My ADS-B" page. Every time a new feeder is detected FlightAware assigns a unique identifier (guid) to it. To ensure your piaware container is not seen as a new feeder each time it is restarted you need to get the "unique identifier" from your My ADS-B stats page and set it in the docker-compose.yml file.
 
@@ -65,6 +65,27 @@ Log into your FlightAware account and find your new feeder on the "My ADS-B" pag
     ```
 
 This will ensure that when your piaware container is restarted that it is seen as the same feeder in flightaware. 
+
+## Setting your feeder key -- FlightRadar24.com (optional)
+
+Before you can feed FlightRadar24.com you need to create an account on their website. Then you need to run the flightaware container with a signup command to register and generate your key.
+
+If you dont want to feed FlightRadar24.com comment out the flightradar service in the docker-compose.yml
+
+
+    ```
+    $ docker run -it loungefly/raspbian-flightradar24 /usr/bin/fr24feed --signup
+    ```
+
+Step 1.1 Enter your accounts email address
+Step 1.2 Leave blank
+Step 1.3 yes
+Step 3.A Enter your latitude
+Step 3.B Enter your longitude
+Step 3.C Enter your altitude in feet
+Enter 'yes' to confirm
+
+You should be given a key that you can copy and enter into the docker-compose.yml file in the FR24_KEY environment variable.
 
 ## Troubleshooting
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,29 @@
+version: '3.2'
+services:
+  dump1090:
+    image: "loungefly/raspbian-dump1090"
+    build: ./dump1090
+    container_name: dump1090
+    privileged: true
+    ports:
+     - "8080:8080"
+     - "30003:30003"
+     - "30005:30005"
+     - "30104:30104"
+    environment:
+      - DUMP_HTTP_PORT=8080
+      - DUMP_SBS_PORT=30003
+      - DUMP_LAT=49.555
+      - DUMP_LON=-124.555
+  piaware:
+    image: "loungefly/raspbian-flightaware"
+    container_name: piaware
+    build: ./flightaware
+    volumes:
+      - ./flightaware/piaware.conf:/etc/piaware.conf
+    environment:
+      - PIAWARE_HOST=dump1090
+      - PIAWARE_PORT=30005
+      - PIAWARE_USER=username
+      - PIAWARE_PASSWORD=password
+      - PIAWARE_FEEDER_ID=

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -27,3 +27,14 @@ services:
       - PIAWARE_USER=username
       - PIAWARE_PASSWORD=password
       - PIAWARE_FEEDER_ID=
+  flightradar:
+    image: "loungefly/raspbian-flightradar24"
+    container_name: flightradar24
+    build: ./flightradar
+    ports:
+     - "8754:8754"
+    environment:
+      - DUMP1090_HOST=dump1090
+      - DUMP1090_PORT=30005
+      - FR24_KEY=
+    restart: always

--- a/dump1090/Dockerfile
+++ b/dump1090/Dockerfile
@@ -1,0 +1,48 @@
+FROM resin/rpi-raspbian:jessie
+ENTRYPOINT []
+
+WORKDIR /root
+
+RUN apt-get update -qy \
+ && apt-get install --no-install-recommends -qy \
+    git-core \
+    git \
+    cmake \
+    libusb-1.0.0-dev \
+    build-essential \
+    pkg-config
+
+RUN git clone git://git.osmocom.org/rtl-sdr.git \
+    && mkdir -p ./rtl-sdr/build \
+    && cd /root/rtl-sdr/build \
+    && cmake ../ -DINSTALL_UDEV_RULES=ON \
+    && make -j 4 \
+    && make install \
+    && ldconfig \
+    && cp /root/rtl-sdr/rtl-sdr.rules /etc/udev/rules.d/
+    
+#RUN git clone https://github.com/mutability/dump1090 \
+#    && cd dump1090 \
+#    && make -j 4
+    
+RUN git clone https://github.com/malcolmrobb/dump1090 \
+    && cd dump1090 \
+    && make -j 4
+
+# web overview
+EXPOSE 8080
+
+# ports for FlightAware etc
+EXPOSE 30003
+EXPOSE 30005
+EXPOSE 30104
+
+WORKDIR /root/dump1090
+
+COPY ./startdumping.sh startdumping.sh
+RUN chmod +x startdumping.sh
+
+# Update your lat/lon values.
+ENV DUMP_HTTP_PORT="" DUMP_SBS_PORT="" DUMP_LAT="" DUMP_LON="" 
+
+CMD ["/root/dump1090/startdumping.sh"]

--- a/dump1090/startdumping.sh
+++ b/dump1090/startdumping.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+./dump1090 --net-http-port $DUMP_HTTP_PORT --net --net-sbs-port $DUMP_SBS_PORT --interactive --lat $DUMP_LAT --lon $DUMP_LON

--- a/flightaware/Dockerfile
+++ b/flightaware/Dockerfile
@@ -11,4 +11,9 @@ RUN wget http://uk.flightaware.com/adsb/piaware/files/packages/pool/piaware/p/pi
 EXPOSE 8080
 EXPOSE 30003
 
-CMD ["piaware", "-debug"]
+COPY ./start.sh start.sh
+RUN chmod +x start.sh
+
+ENV PIAWARE_HOST="" PIAWARE_PORT="" PIAWARE_USER="" PIAWARE_PASSWORD="" PIAWARE_FEEDER_ID=""
+
+CMD ["/start.sh"]

--- a/flightaware/start.sh
+++ b/flightaware/start.sh
@@ -1,11 +1,31 @@
 #!/bin/bash
 
-echo "receiver-type other" > /etc/piaware.conf
-echo "receiver-host $PIAWARE_HOST" >> /etc/piaware.conf
-echo "receiver-port $PIAWARE_PORT" >> /etc/piaware.conf
-echo "flightaware-user $PIAWARE_USER" >> /etc/piaware.conf
-echo "flightaware-password $PIAWARE_PASSWORD" >> /etc/piaware.conf
-echo "mlat-results no" >> /etc/piaware.conf
-echo "feeder-id $PIAWARE_FEEDER_ID" >> /etc/piaware.conf
+/usr/bin/piaware-config mlat-results no
+/usr/bin/piaware-config reciever-type other
+
+[[ ! -z ${PIAWARE_HOST} ]]             &&  /usr/bin/piaware-config reciever-port ${PIAWARE_HOST} || PIAWARE_HOST="dump1090"
+[[ ! -z ${PIAWARE_PORT} ]]             &&  /usr/bin/piaware-config reciever-port ${PIAWARE_PORT} || PIAWARE_PORT="30005"
+[[ ! -z ${PIAWARE_FEEDER_ID} ]]       && /usr/bin/piaware-config feeder-id ${PIAWARE_FEEDER_ID}
+
+# Recommend adding this to the config
+[[ ! -z ${GAIN} ]]             && /usr/bin/piaware-config rtlsdr-gain ${GAIN} || GAIN="-10"
+[[ ! -z ${PPM} ]]              && /usr/bin/piaware-config rtlsdr-ppm ${PPM} || PPM="1"
+
+# These are old ways of flight-aware/piaware
+
+if [[ ! -z ${PIAWARE_USER} ]] && [[ -z ${PIAWARE_FEEDER_ID} ]]; then
+    echo "WARNING: flightaware-user has been deprecated."
+    /usr/bin/piaware-config flightaware-user ${PIAWARE_USERNAME}
+fi
+
+if [[ ! -z ${PIAWARE_PASSWORD} ]] && [[ -z ${PIAWARE_FEEDER_ID} ]]; then
+    echo "WARNING: flightaware-password has been deprecated."
+    /usr/bin/piaware-config flightaware-password ${PIAWARE_PASSWORD}
+fi
+
+if [[ ! -z ${PIAWARE_MAC} ]]; then
+    echo "WARNING: force-macaddress has been deprecated."
+    /usr/bin/piaware-config force-macaddress ${PIAWARE_MAC}
+fi
 
 /usr/bin/piaware -debug

--- a/flightaware/start.sh
+++ b/flightaware/start.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+echo "receiver-type other" > /etc/piaware.conf
+echo "receiver-host $PIAWARE_HOST" >> /etc/piaware.conf
+echo "receiver-port $PIAWARE_PORT" >> /etc/piaware.conf
+echo "flightaware-user $PIAWARE_USER" >> /etc/piaware.conf
+echo "flightaware-password $PIAWARE_PASSWORD" >> /etc/piaware.conf
+echo "mlat-results no" >> /etc/piaware.conf
+echo "feeder-id $PIAWARE_FEEDER_ID" >> /etc/piaware.conf
+
+/usr/bin/piaware -debug

--- a/flightaware/start.sh
+++ b/flightaware/start.sh
@@ -1,10 +1,10 @@
 #!/bin/bash
 
 /usr/bin/piaware-config mlat-results no
-/usr/bin/piaware-config reciever-type other
+/usr/bin/piaware-config receiver-type other
 
-[[ ! -z ${PIAWARE_HOST} ]]             &&  /usr/bin/piaware-config reciever-port ${PIAWARE_HOST} || PIAWARE_HOST="dump1090"
-[[ ! -z ${PIAWARE_PORT} ]]             &&  /usr/bin/piaware-config reciever-port ${PIAWARE_PORT} || PIAWARE_PORT="30005"
+[[ ! -z ${PIAWARE_HOST} ]]             &&  /usr/bin/piaware-config receiver-host ${PIAWARE_HOST} || PIAWARE_HOST="dump1090"
+[[ ! -z ${PIAWARE_PORT} ]]             &&  /usr/bin/piaware-config receiver-port ${PIAWARE_PORT} || PIAWARE_PORT="30005"
 [[ ! -z ${PIAWARE_FEEDER_ID} ]]       && /usr/bin/piaware-config feeder-id ${PIAWARE_FEEDER_ID}
 
 # Recommend adding this to the config

--- a/flightradar/Dockerfile
+++ b/flightradar/Dockerfile
@@ -1,0 +1,26 @@
+FROM resin/rpi-raspbian:jessie
+
+# Import GPG key for the APT repository
+RUN gpg --keyserver pgp.mit.edu --recv-keys 40C430F5 && \
+    gpg --armor --export 40C430F5 | apt-key add -
+
+# Add APT repository to the config file, removing older entries if exist
+ RUN mv /etc/apt/sources.list /etc/apt/sources.list.bak && \
+     grep -v flightradar24 /etc/apt/sources.list.bak > /etc/apt/sources.list && \
+     echo 'deb http://repo.feed.flightradar24.com flightradar24 raspberrypi-stable' >> /etc/apt/sources.list
+
+RUN apt-get update && apt-get install --assume-yes --no-install-recommends \
+    fr24feed
+
+# needed for some network utils that i think flightradar needs to connect (possibly openSSL)
+RUN apt-get install iputils-ping && \
+  apt-get install nano
+
+COPY ./start.sh start.sh
+RUN chmod +x start.sh
+
+EXPOSE 8754
+
+ENV DUMP1090_HOST="" DUMP1090_PORT="" FR24_KEY="" 
+
+CMD ["/start.sh"]

--- a/flightradar/start.sh
+++ b/flightradar/start.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+/usr/bin/fr24feed --fr24key=$FR24_KEY --receiver=beast-tcp --logmode=1 --host=$DUMP1090_HOST:$DUMP1090_PORT --logpath=/var/log --mlat=yes mlat-without-gps=yes --bs=no --raw=yes


### PR DESCRIPTION
This PR includes a number changes to make eyes-in-the-sky docker-compose friendly:

1. move all container configuration to env vars
2. add suitable docker-compose.yml file
3. move all configuration to the docker-compose.yml file
4. updated readme with instructions on using docker-compose on the raspberry pi

Note: The compose currently points to my hub image.  This could be changed once the images from the original build were updated to use this new environment based config.

Thanks
-Chris